### PR TITLE
feat: add Energy Intelligence dashboard with carbon correlation and smart insights #4

### DIFF
--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -1,0 +1,312 @@
+# Energy Intelligence Dashboard
+#
+# Multi-integration dashboard correlating Octopus Energy rates/costs/carbon,
+# SolaX inverter data, and UK Carbon Intensity forecasts.
+#
+# Entity placeholders replaced at deploy time by scripts/deploy_energy_intelligence.py:
+#   OCTOPUS_IMPORT_*  — Electricity import meter sensors
+#   OCTOPUS_EXPORT_*  — Electricity export meter sensors
+#   OCTOPUS_GAS_*     — Gas meter sensors
+#   OCTOPUS_ENTRY_*   — Entry-level sensors (tariff_comparison, solar_estimate, carbon_correlation)
+#   SOLAX_*           — SolaX inverter sensors
+#   Carbon intensity entities use fixed names (no placeholders needed)
+
+views:
+  - title: Energy Intelligence
+    path: energy-intelligence
+    icon: mdi:flash-alert
+    cards:
+      # ── Section 1: Right Now ──────────────────────────────────────────
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Right Now"
+
+          - type: horizontal-stack
+            cards:
+              - type: gauge
+                entity: sensor.octopus_energy_OCTOPUS_IMPORT_current_rate
+                name: Import Rate
+                unit: p/kWh
+                needle: true
+                min: 0
+                max: 50
+                segments:
+                  - from: 0
+                    color: green
+                  - from: 10
+                    color: amber
+                  - from: 25
+                    color: red
+
+              - type: gauge
+                entity: sensor.uk_carbon_intensity_national_carbon_intensity
+                name: Grid Carbon
+                unit: gCO2/kWh
+                needle: true
+                min: 0
+                max: 400
+                segments:
+                  - from: 0
+                    color: green
+                  - from: 150
+                    color: amber
+                  - from: 250
+                    color: red
+
+              - type: gauge
+                entity: sensor.SOLAX_battery_state_of_charge
+                name: Battery SOC
+                unit: "%"
+                needle: true
+                min: 0
+                max: 100
+                segments:
+                  - from: 0
+                    color: red
+                  - from: 20
+                    color: amber
+                  - from: 50
+                    color: green
+
+          - type: markdown
+            title: Smart Status
+            content: >
+              {% set rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
+              {% set carbon_index = states('sensor.uk_carbon_intensity_national_carbon_index') %}
+              {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
+              {% set grid_power = states('sensor.SOLAX_grid_power') | float(0) %}
+              {% set pv1 = states('sensor.SOLAX_pv1_power') | float(0) %}
+              {% set pv2 = states('sensor.SOLAX_pv2_power') | float(0) %}
+              {% set pv_total = pv1 + pv2 %}
+              {% if grid_power < -100 %}
+              **Exporting solar surplus** ({{ (grid_power | abs) | round(0) | int }}W to grid)
+              {% elif pv_total > 500 and battery_soc < 95 %}
+              **Charging battery from solar** ({{ pv_total | round(0) | int }}W PV)
+              {% elif rate > 25 and battery_soc > 20 %}
+              **Expensive period** — using battery ({{ battery_soc | round(0) | int }}% SOC)
+              {% elif carbon_index in ['high', 'very high'] %}
+              **High carbon grid** — defer heavy loads if possible
+              {% elif rate < 10 %}
+              **Cheap period** — good time for high-demand tasks
+              {% elif carbon_index in ['low', 'very low'] %}
+              **Clean grid** — carbon intensity is {{ carbon_index }}
+              {% else %}
+              **Normal operation** — {{ rate | round(1) }}p/kWh, carbon {{ carbon_index }}
+              {% endif %}
+
+          - type: entities
+            title: Current Readings
+            entities:
+              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_current_rate
+                name: Import rate
+              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_next_rate
+                name: Next rate
+              - entity: sensor.octopus_energy_OCTOPUS_EXPORT_export_current_rate
+                name: Export rate
+              - entity: sensor.uk_carbon_intensity_national_carbon_index
+                name: Carbon index
+              - entity: sensor.SOLAX_battery_power
+                name: Battery power
+              - entity: sensor.SOLAX_grid_power
+                name: Grid power
+
+      # ── Section 2: Yesterday's Review ──────────────────────────────────
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Yesterday's Review"
+
+          - type: horizontal-stack
+            cards:
+              - type: entity
+                entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption
+                name: Consumption
+              - type: entity
+                entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost
+                name: Cost
+              - type: entity
+                entity: sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation
+                name: Carbon Avg
+
+          - type: markdown
+            title: Carbon Analysis
+            content: >
+              {% set carbon = state_attr('sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation', 'carbon_summary') %}
+              {% if carbon %}
+              | Metric | Value |
+              |--------|-------|
+              | **Total CO2** | {{ carbon.total_grams_co2 | round(0) | int }}g ({{ (carbon.total_grams_co2 / 1000) | round(2) }}kg) |
+              | **Avg intensity** | {{ carbon.weighted_avg_intensity }}gCO2/kWh |
+              | **High-carbon usage** | {{ carbon.high_carbon_kwh }}kWh ({{ carbon.high_carbon_pct }}%) |
+              | **Low-carbon usage** | {{ carbon.low_carbon_kwh }}kWh ({{ carbon.low_carbon_pct }}%) |
+              {% else %}
+              *Carbon analysis will appear once the integration loads with consumption and carbon data.*
+              {% endif %}
+
+          - type: markdown
+            title: Optimization Insights
+            content: >
+              {% set opt = state_attr('sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation', 'optimization') %}
+              {% if opt and opt.cheapest_2h_window is defined %}
+              {% set cheap = opt.cheapest_2h_window %}
+              {% set green = opt.greenest_2h_window %}
+              **Cheapest 2h window yesterday:** {{ cheap.start[11:16] }}–{{ cheap.end[11:16] }} (avg {{ cheap.avg_rate }}p/kWh)
+
+              **Greenest 2h window yesterday:** {{ green.start[11:16] }}–{{ green.end[11:16] }} (avg {{ green.avg_intensity }}gCO2/kWh)
+
+              {% if cheap.start != green.start %}
+              *The cheapest and greenest windows differed — consider prioritising carbon or cost
+              depending on your goals.*
+              {% else %}
+              *The cheapest window was also the greenest — optimal alignment!*
+              {% endif %}
+              {% else %}
+              *Optimization data will appear once the carbon correlation sensor has data.*
+              {% endif %}
+
+          - type: markdown
+            title: Net Cost
+            content: >
+              {% set import_cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') %}
+              {% set has_data = import_cost not in ['unknown', 'unavailable'] %}
+              {% if has_data %}
+              {% set ic = import_cost | float(0) %}
+              {% set export_revenue = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_cost') | float(0) %}
+              {% set gas_cost = states('sensor.octopus_energy_OCTOPUS_GAS_gas_previous_cost') | float(0) %}
+              {% set elec_standing = states('sensor.octopus_energy_OCTOPUS_IMPORT_standing_charge') | float(0) / 100 %}
+              {% set gas_standing = states('sensor.octopus_energy_OCTOPUS_GAS_gas_standing_charge') | float(0) / 100 %}
+              {% set net = ic - export_revenue + gas_cost + elec_standing + gas_standing %}
+              **Net daily cost: £{{ '%.2f' | format(net) }}**
+
+              | | |
+              |---|---|
+              | Electricity import | £{{ '%.2f' | format(ic) }} |
+              | Export revenue | -£{{ '%.2f' | format(export_revenue) }} |
+              | Gas | £{{ '%.2f' | format(gas_cost) }} |
+              | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
+              {% else %}
+              *Awaiting yesterday's consumption data.*
+              {% endif %}
+
+      # ── Section 3: Tomorrow's Outlook ──────────────────────────────────
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Tomorrow's Outlook"
+
+          - type: horizontal-stack
+            cards:
+              - type: entity
+                entity: sensor.octopus_energy_OCTOPUS_ENTRY_solar_estimate
+                name: Solar Forecast
+              - type: entity
+                entity: sensor.uk_carbon_intensity_lowest_forecast_intensity
+                name: Lowest Carbon
+
+          - type: markdown
+            title: Recommendation
+            content: >
+              {% set solar = states('sensor.octopus_energy_OCTOPUS_ENTRY_solar_estimate') | float(0) %}
+              {% set lowest_carbon = states('sensor.uk_carbon_intensity_lowest_forecast_intensity') | float(0) %}
+              {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
+              {% if solar > 15 %}
+              **Sunny day ahead** ({{ solar | round(1) }}kWh forecast) — skip overnight charging,
+              solar should cover daytime needs and recharge the battery.
+              {% elif solar > 8 %}
+              **Moderate solar** ({{ solar | round(1) }}kWh forecast) — consider a partial overnight
+              charge to 50% if battery is low, solar will top up the rest.
+              {% elif solar > 0 %}
+              **Low solar** ({{ solar | round(1) }}kWh forecast) — charge battery overnight during
+              the cheapest window for best cost savings.
+              {% else %}
+              *Solar forecast not available. Check integration settings.*
+              {% endif %}
+
+              {% if lowest_carbon < 100 %}
+              Grid will be very clean ({{ lowest_carbon | round(0) | int }}gCO2/kWh) — great time
+              to charge from grid if needed.
+              {% elif lowest_carbon < 200 %}
+              Moderate grid carbon forecast ({{ lowest_carbon | round(0) | int }}gCO2/kWh).
+              {% endif %}
+
+          - type: markdown
+            title: Carbon Forecast
+            content: >
+              {% set current = states('sensor.uk_carbon_intensity_national_carbon_intensity') | float(0) %}
+              {% set index = states('sensor.uk_carbon_intensity_national_carbon_index') %}
+              {% set low_carbon = states('sensor.uk_carbon_intensity_low_carbon_percentage') | float(0) %}
+              {% set fossil = states('sensor.uk_carbon_intensity_fossil_fuel_percentage') | float(0) %}
+              {% set wind = states('sensor.uk_carbon_intensity_wind_generation') | float(0) %}
+              {% set solar_gen = states('sensor.uk_carbon_intensity_solar_generation') | float(0) %}
+              | Metric | Value |
+              |--------|-------|
+              | **Current intensity** | {{ current | round(0) | int }}gCO2/kWh ({{ index }}) |
+              | **Low-carbon generation** | {{ low_carbon | round(1) }}% |
+              | **Fossil fuel** | {{ fossil | round(1) }}% |
+              | **Wind** | {{ wind | round(1) }}% |
+              | **Solar** | {{ solar_gen | round(1) }}% |
+
+      # ── Section 4: Energy Ratios ──────────────────────────────────────
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Energy Ratios"
+
+          - type: markdown
+            title: Self-Consumption & Export
+            content: >
+              {% set import_kwh = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
+              {% set export_kwh = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_consumption') | float(0) %}
+              {% set pv_today = states('sensor.SOLAX_today_pv_energy') | float(0) %}
+              {% set total_gen = pv_today if pv_today > 0 else 1 %}
+              {% set self_consumed = total_gen - export_kwh if total_gen > export_kwh else 0 %}
+              {% set self_pct = (self_consumed / total_gen * 100) if total_gen > 0 else 0 %}
+              {% set export_pct = (export_kwh / total_gen * 100) if total_gen > 0 else 0 %}
+              {% if pv_today > 0 %}
+              | Metric | Value |
+              |--------|-------|
+              | **PV generated** | {{ pv_today | round(2) }}kWh |
+              | **Self-consumed** | {{ self_consumed | round(2) }}kWh ({{ self_pct | round(0) | int }}%) |
+              | **Exported** | {{ export_kwh | round(2) }}kWh ({{ export_pct | round(0) | int }}%) |
+              | **Grid import** | {{ import_kwh | round(2) }}kWh |
+              {% else %}
+              *PV generation data will appear once the inverter produces energy today.*
+              {% endif %}
+
+          - type: markdown
+            title: Grid Carbon Split
+            content: >
+              {% set low_carbon = states('sensor.uk_carbon_intensity_low_carbon_percentage') | float(0) %}
+              {% set fossil = states('sensor.uk_carbon_intensity_fossil_fuel_percentage') | float(0) %}
+              | Source | Share |
+              |--------|-------|
+              | **Clean energy** | {{ low_carbon | round(1) }}% |
+              | **Fossil fuel** | {{ fossil | round(1) }}% |
+
+      # ── Section 5: Weekly Trends ──────────────────────────────────────
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Weekly Trends"
+
+          - type: statistics-graph
+            title: PV Generation & Consumption (7 days)
+            entities:
+              - entity: sensor.SOLAX_total_pv_energy
+                name: PV Total
+              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption
+                name: Import
+              - entity: sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_consumption
+                name: Export
+            days_to_show: 7
+            stat_types:
+              - change
+            period: day
+
+          - type: history-graph
+            title: Battery SOC (7 days)
+            entities:
+              - entity: sensor.SOLAX_battery_state_of_charge
+                name: Battery SOC
+            hours_to_show: 168

--- a/dashboards/octopus-energy.yaml
+++ b/dashboards/octopus-energy.yaml
@@ -1,0 +1,174 @@
+# Octopus Energy Intelligence Dashboard
+#
+# Lovelace dashboard template for the custom ha-octopus-energy integration.
+# Entity IDs use placeholders (ELECTRICITY_METER, EXPORT_METER, GAS_METER,
+# ACCOUNT) which are replaced by scripts/deploy_dashboard.py at deploy time.
+#
+# Sections:
+#   1. Right Now — live pricing gauges for immediate consumption decisions
+#   2. Yesterday — daily cost accountability
+#   3. Tariff Comparison — strategic tariff switching
+#   4. Solar Forecast — plan consumption around solar
+#   5. Octopus Recommends — cross-reference with Octopus's own analysis
+
+views:
+  - title: Octopus Energy
+    path: octopus-energy
+    icon: mdi:octagram
+    cards:
+      # ── Section 1: Right Now ──────────────────────────────────────────
+      - type: markdown
+        content: "## Right Now"
+
+      - type: horizontal-stack
+        cards:
+          - type: gauge
+            entity: sensor.octopus_energy_ELECTRICITY_METER_current_rate
+            name: Import Rate
+            unit: p/kWh
+            needle: true
+            min: 0
+            max: 50
+            segments:
+              - from: 0
+                color: green
+              - from: 10
+                color: amber
+              - from: 25
+                color: red
+
+          - type: gauge
+            entity: sensor.octopus_energy_ELECTRICITY_METER_next_rate
+            name: Next Rate
+            unit: p/kWh
+            needle: true
+            min: 0
+            max: 50
+            segments:
+              - from: 0
+                color: green
+              - from: 10
+                color: amber
+              - from: 25
+                color: red
+
+          - type: gauge
+            entity: sensor.octopus_energy_EXPORT_METER_export_current_rate
+            name: Export Rate
+            unit: p/kWh
+            needle: true
+            min: 0
+            max: 30
+            segments:
+              - from: 0
+                color: red
+              - from: 10
+                color: amber
+              - from: 15
+                color: green
+
+      - type: entities
+        title: Standing Charges
+        entities:
+          - entity: sensor.octopus_energy_ELECTRICITY_METER_standing_charge
+            name: Electricity
+          - entity: sensor.octopus_energy_GAS_METER_gas_standing_charge
+            name: Gas
+
+      # ── Section 2: Yesterday ──────────────────────────────────────────
+      - type: markdown
+        content: "## Yesterday"
+
+      - type: horizontal-stack
+        cards:
+          - type: entity
+            entity: sensor.octopus_energy_ELECTRICITY_METER_previous_cost
+            name: Import Cost
+            icon: mdi:currency-gbp
+          - type: entity
+            entity: sensor.octopus_energy_ELECTRICITY_METER_previous_consumption
+            name: Import Usage
+            icon: mdi:flash
+          - type: entity
+            entity: sensor.octopus_energy_EXPORT_METER_export_previous_cost
+            name: Export Revenue
+            icon: mdi:cash-plus
+
+      - type: horizontal-stack
+        cards:
+          - type: entity
+            entity: sensor.octopus_energy_GAS_METER_gas_previous_cost
+            name: Gas Cost
+            icon: mdi:fire
+          - type: entity
+            entity: sensor.octopus_energy_GAS_METER_gas_previous_consumption
+            name: Gas Usage
+            icon: mdi:meter-gas
+
+      - type: markdown
+        title: Net Cost
+        content: >
+          {% set import_cost = states('sensor.octopus_energy_ELECTRICITY_METER_previous_cost') | float(0) %}
+          {% set export_revenue = states('sensor.octopus_energy_EXPORT_METER_export_previous_cost') | float(0) %}
+          {% set gas_cost = states('sensor.octopus_energy_GAS_METER_gas_previous_cost') | float(0) %}
+          {% set elec_standing = states('sensor.octopus_energy_ELECTRICITY_METER_standing_charge') | float(0) / 100 %}
+          {% set gas_standing = states('sensor.octopus_energy_GAS_METER_gas_standing_charge') | float(0) / 100 %}
+          {% set net = import_cost - export_revenue + gas_cost + elec_standing + gas_standing %}
+          **Net daily cost: {{ '%.2f' | format(net) }}**
+
+          | | |
+          |---|---|
+          | Electricity import | {{ '%.2f' | format(import_cost) }} |
+          | Export revenue | -{{ '%.2f' | format(export_revenue) }} |
+          | Gas | {{ '%.2f' | format(gas_cost) }} |
+          | Standing charges | {{ '%.2f' | format(elec_standing + gas_standing) }} |
+
+      # ── Section 3: Tariff Comparison ──────────────────────────────────
+      - type: markdown
+        content: "## Tariff Comparison"
+
+      - type: custom:octopus-tariff-comparison-card
+        entity: sensor.octopus_energy_ACCOUNT_tariff_comparison
+
+      # ── Section 4: Solar Forecast ─────────────────────────────────────
+      - type: markdown
+        content: "## Solar Forecast"
+
+      - type: entity
+        entity: sensor.octopus_energy_ACCOUNT_solar_estimate
+        name: Today's Solar Estimate
+        icon: mdi:solar-power
+
+      - type: markdown
+        title: Hourly Solar Breakdown
+        content: >
+          {% set estimates = state_attr('sensor.octopus_energy_ACCOUNT_solar_estimate', 'hourly_estimates') %}
+          {% if estimates %}
+          | Hour | kWh |
+          |------|-----|
+          {% for e in estimates %}
+          | {{ '%02d' | format(e.hour) }}:00 | {{ '%.2f' | format(e.value) }} |
+          {% endfor %}
+          {% else %}
+          *Solar estimate data unavailable*
+          {% endif %}
+
+      # ── Section 5: Octopus Recommends ─────────────────────────────────
+      - type: markdown
+        content: "## Octopus Recommends"
+
+      - type: markdown
+        title: Smart Comparison
+        content: >
+          {% set comp = state_attr('sensor.octopus_energy_ACCOUNT_tariff_comparison', 'octopus_comparison') %}
+          {% if comp %}
+          **Your current cost:** {{ '%.2f' | format(comp.current_cost) }}
+
+          | Tariff | Estimated Cost |
+          |--------|---------------|
+          {% for alt in comp.alternatives %}
+          | {{ alt.product_code }} | {{ '%.2f' | format(alt.cost) }} |
+          {% endfor %}
+          {% else %}
+          *Octopus comparison data unavailable — check that the integration has fetched comparison data.*
+          {% endif %}

--- a/scripts/deploy_dashboard.py
+++ b/scripts/deploy_dashboard.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Deploy the Octopus Energy Intelligence dashboard to Home Assistant.
+
+Connects via WebSocket, discovers octopus_energy entity IDs, substitutes
+them into the dashboard template, and pushes via lovelace/dashboards/create
++ lovelace/config/save.
+
+Usage:
+    python3 scripts/deploy_dashboard.py
+
+Requires: pip install websockets pyyaml
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import websockets
+except ImportError:
+    print("ERROR: websockets package required. Install with: pip3 install websockets")
+    sys.exit(1)
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml package required. Install with: pip3 install pyyaml")
+    sys.exit(1)
+
+HA_URL = "ws://192.168.1.227:8123/api/websocket"
+DASHBOARD_URL_PATH = "octopus-energy"
+DASHBOARD_TITLE = "Octopus Energy"
+DASHBOARD_ICON = "mdi:octagram"
+
+# Placeholder entity IDs used in the dashboard template YAML.
+# Each maps to a suffix regex that identifies the real entity.
+# The regex matches against the full entity_id (after "sensor.octopus_energy_").
+ENTITY_MAP = {
+    # Electricity import
+    "ELECTRICITY_METER_current_rate": r"(?!.*export).*_current_rate$",
+    "ELECTRICITY_METER_next_rate": r"(?!.*export).*_next_rate$",
+    "ELECTRICITY_METER_previous_consumption": r"(?!.*export).*(?<!gas)_previous_consumption$",
+    "ELECTRICITY_METER_previous_cost": r"(?!.*export).*(?<!gas)_previous_cost$",
+    "ELECTRICITY_METER_standing_charge": r"(?!.*export).*(?<!gas)_standing_charge$",
+    # Electricity export
+    "EXPORT_METER_export_current_rate": r".*_export_current_rate$",
+    "EXPORT_METER_export_next_rate": r".*_export_next_rate$",
+    "EXPORT_METER_export_previous_consumption": r".*_export_previous_consumption$",
+    "EXPORT_METER_export_previous_cost": r".*_export_previous_cost$",
+    # Gas
+    "GAS_METER_gas_current_rate": r".*_gas_current_rate$",
+    "GAS_METER_gas_previous_consumption": r".*_gas_previous_consumption$",
+    "GAS_METER_gas_previous_cost": r".*_gas_previous_cost$",
+    "GAS_METER_gas_standing_charge": r".*_gas_standing_charge$",
+    # Account-level
+    "ACCOUNT_tariff_comparison": r".*_tariff_comparison$",
+    "ACCOUNT_solar_estimate": r".*_solar_estimate$",
+}
+
+PREFIX = "sensor.octopus_energy_"
+
+
+def load_token() -> str:
+    """Read the HA long-lived access token."""
+    token_path = Path(__file__).resolve().parent.parent / ".claude" / "accessToken"
+    if not token_path.exists():
+        print(f"ERROR: Token file not found at {token_path}")
+        sys.exit(1)
+    return token_path.read_text().strip()
+
+
+def load_template() -> str:
+    """Load the dashboard YAML template as a string."""
+    template_path = (
+        Path(__file__).resolve().parent.parent / "dashboards" / "octopus-energy.yaml"
+    )
+    if not template_path.exists():
+        print(f"ERROR: Dashboard template not found at {template_path}")
+        sys.exit(1)
+    return template_path.read_text()
+
+
+def discover_entities(entities: list[dict]) -> dict[str, str]:
+    """Map placeholder entity IDs to real entity IDs.
+
+    Returns a dict like:
+        {"sensor.octopus_energy_ELECTRICITY_METER_current_rate":
+         "sensor.octopus_energy_1100009640372_s71fm19329_current_rate"}
+    """
+    oe_sensors = sorted(
+        e["entity_id"]
+        for e in entities
+        if e["entity_id"].startswith(PREFIX)
+    )
+
+    if not oe_sensors:
+        print("ERROR: No sensor.octopus_energy_* entities found in HA")
+        sys.exit(1)
+
+    print(f"Found {len(oe_sensors)} Octopus Energy sensor entities:")
+    for eid in oe_sensors:
+        print(f"  {eid}")
+
+    replacements: dict[str, str] = {}
+
+    for placeholder, pattern in ENTITY_MAP.items():
+        placeholder_full = f"{PREFIX}{placeholder}"
+        matched = False
+        for eid in oe_sensors:
+            bare = eid[len(PREFIX):]
+            if re.match(pattern, bare):
+                replacements[placeholder_full] = eid
+                print(f"  {placeholder} -> {eid}")
+                matched = True
+                break
+        if not matched:
+            print(f"  {placeholder} -> NOT FOUND (cards will show unavailable)")
+
+    return replacements
+
+
+def substitute_template(template: str, replacements: dict[str, str]) -> dict:
+    """Replace placeholder entity IDs in the YAML template with real ones."""
+    result = template
+    for placeholder, real_id in replacements.items():
+        result = result.replace(placeholder, real_id)
+
+    # Warn about any remaining placeholders
+    remaining = re.findall(
+        r"sensor\.octopus_energy_(?:ELECTRICITY_METER|EXPORT_METER|GAS_METER|ACCOUNT)_\w+",
+        result,
+    )
+    if remaining:
+        unique = sorted(set(remaining))
+        print(f"\nWARNING: {len(unique)} unresolved placeholder(s):")
+        for p in unique:
+            print(f"  {p}")
+        print("  Cards referencing these entities will show 'unavailable'")
+
+    return yaml.safe_load(result)
+
+
+async def deploy(token: str) -> None:
+    """Connect to HA WebSocket and deploy the dashboard."""
+    msg_id = 1
+
+    async def send(ws, payload: dict) -> dict:
+        nonlocal msg_id
+        payload["id"] = msg_id
+        msg_id += 1
+        await ws.send(json.dumps(payload))
+        while True:
+            resp = json.loads(await ws.recv())
+            if resp.get("id") == payload["id"]:
+                return resp
+
+    async with websockets.connect(HA_URL) as ws:
+        # Wait for auth_required
+        auth_req = json.loads(await ws.recv())
+        if auth_req.get("type") != "auth_required":
+            print(f"ERROR: Expected auth_required, got {auth_req.get('type')}")
+            sys.exit(1)
+
+        # Authenticate
+        await ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth_resp = json.loads(await ws.recv())
+        if auth_resp.get("type") != "auth_ok":
+            print(f"ERROR: Authentication failed: {auth_resp}")
+            sys.exit(1)
+        print("Authenticated with Home Assistant\n")
+
+        # Discover entities
+        entity_resp = await send(ws, {"type": "config/entity_registry/list"})
+        if not entity_resp.get("success"):
+            print(f"ERROR: Failed to list entities: {entity_resp}")
+            sys.exit(1)
+
+        replacements = discover_entities(entity_resp["result"])
+        if not replacements:
+            print("ERROR: Could not identify any Octopus Energy entities")
+            sys.exit(1)
+
+        # Generate final config
+        template = load_template()
+        dashboard_config = substitute_template(template, replacements)
+
+        # Check if dashboard already exists
+        resp = await send(ws, {"type": "lovelace/dashboards/list"})
+        if not resp.get("success"):
+            print(f"ERROR: Failed to list dashboards: {resp}")
+            sys.exit(1)
+
+        existing = [
+            d for d in resp["result"] if d.get("url_path") == DASHBOARD_URL_PATH
+        ]
+
+        if existing:
+            print(
+                f"\nDashboard '{DASHBOARD_URL_PATH}' already exists, updating config..."
+            )
+        else:
+            create_resp = await send(
+                ws,
+                {
+                    "type": "lovelace/dashboards/create",
+                    "url_path": DASHBOARD_URL_PATH,
+                    "title": DASHBOARD_TITLE,
+                    "icon": DASHBOARD_ICON,
+                    "require_admin": False,
+                    "show_in_sidebar": True,
+                },
+            )
+            if not create_resp.get("success"):
+                print(f"ERROR: Failed to create dashboard: {create_resp}")
+                sys.exit(1)
+            print(f"\nCreated dashboard at /{DASHBOARD_URL_PATH}")
+
+        # Save the dashboard config
+        save_resp = await send(
+            ws,
+            {
+                "type": "lovelace/config/save",
+                "url_path": DASHBOARD_URL_PATH,
+                "config": dashboard_config,
+            },
+        )
+        if not save_resp.get("success"):
+            print(f"ERROR: Failed to save dashboard config: {save_resp}")
+            sys.exit(1)
+
+        print("Dashboard config saved successfully!")
+        print(f"View at: http://192.168.1.227:8123/{DASHBOARD_URL_PATH}")
+
+
+def main() -> None:
+    token = load_token()
+    asyncio.run(deploy(token))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_energy_intelligence.py
+++ b/scripts/deploy_energy_intelligence.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Deploy the Energy Intelligence dashboard to Home Assistant.
+
+Connects via WebSocket, discovers entities from multiple integrations
+(Octopus Energy, SolaX, UK Carbon Intensity), substitutes placeholders
+in the dashboard template, and pushes via lovelace/dashboards/create
++ lovelace/config/save.
+
+Usage:
+    python3 scripts/deploy_energy_intelligence.py
+
+Requires: pip install websockets pyyaml
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import websockets
+except ImportError:
+    print("ERROR: websockets package required. Install with: pip3 install websockets")
+    sys.exit(1)
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml package required. Install with: pip3 install pyyaml")
+    sys.exit(1)
+
+HA_URL = "ws://192.168.1.227:8123/api/websocket"
+DASHBOARD_URL_PATH = "energy-intelligence"
+DASHBOARD_TITLE = "Energy Intelligence"
+DASHBOARD_ICON = "mdi:flash-alert"
+
+# Octopus Energy entity placeholders (same prefix pattern as deploy_dashboard.py)
+OCTOPUS_PREFIX = "sensor.octopus_energy_"
+OCTOPUS_MAP = {
+    # Electricity import
+    "OCTOPUS_IMPORT_current_rate": r"(?!.*export).*_current_rate$",
+    "OCTOPUS_IMPORT_next_rate": r"(?!.*export).*_next_rate$",
+    "OCTOPUS_IMPORT_previous_consumption": r"(?!.*export).*(?<!gas)_previous_(?:accumulative_)?consumption$",
+    "OCTOPUS_IMPORT_previous_cost": r"(?!.*export).*(?<!gas)_previous_(?:accumulative_)?cost$",
+    "OCTOPUS_IMPORT_standing_charge": r"(?!.*export).*(?<!gas)_(?:current_)?standing_charge$",
+    # Electricity export
+    "OCTOPUS_EXPORT_export_current_rate": r".*_export_current_rate$",
+    "OCTOPUS_EXPORT_export_previous_consumption": r".*_export_previous_(?:accumulative_)?consumption$",
+    "OCTOPUS_EXPORT_export_previous_cost": r".*_export_previous_(?:accumulative_)?cost$",
+    # Gas
+    "OCTOPUS_GAS_gas_previous_cost": r".*(?:gas).*_previous_(?:accumulative_)?cost$",
+    "OCTOPUS_GAS_gas_standing_charge": r".*(?:gas).*_(?:current_)?standing_charge$",
+    # Entry-level (custom integration only)
+    "OCTOPUS_ENTRY_carbon_correlation": r".*_carbon_correlation$",
+    "OCTOPUS_ENTRY_tariff_comparison": r".*_tariff_comparison$",
+    "OCTOPUS_ENTRY_solar_estimate": r".*_solar_estimate$",
+}
+
+# SolaX entity placeholders — prefix discovered from entities matching solax_inverter_*
+SOLAX_MAP = {
+    "battery_state_of_charge": "battery_state_of_charge",
+    "battery_power": "battery_power",
+    "grid_power": "grid_power",
+    "grid_import_export": "grid_import_export",
+    "pv1_power": "pv1_power",
+    "pv2_power": "pv2_power",
+    "today_pv_energy": "today_pv_energy",
+    "total_pv_energy": "total_pv_energy",
+    "total_feed_in_energy": "total_feed_in_energy",
+    "total_consumption": "total_consumption",
+}
+
+
+def load_token() -> str:
+    """Read the HA long-lived access token."""
+    token_path = Path(__file__).resolve().parent.parent / ".claude" / "accessToken"
+    if not token_path.exists():
+        print(f"ERROR: Token file not found at {token_path}")
+        sys.exit(1)
+    return token_path.read_text().strip()
+
+
+def load_template() -> str:
+    """Load the dashboard YAML template as a string."""
+    template_path = (
+        Path(__file__).resolve().parent.parent
+        / "dashboards"
+        / "energy-intelligence.yaml"
+    )
+    if not template_path.exists():
+        print(f"ERROR: Dashboard template not found at {template_path}")
+        sys.exit(1)
+    return template_path.read_text()
+
+
+def discover_octopus_entities(entities: list[dict]) -> dict[str, str]:
+    """Discover Octopus Energy entities by regex matching."""
+    oe_sensors = sorted(
+        e["entity_id"]
+        for e in entities
+        if e["entity_id"].startswith(OCTOPUS_PREFIX)
+    )
+
+    if not oe_sensors:
+        print("WARNING: No sensor.octopus_energy_* entities found")
+        return {}
+
+    print(f"\nOctopus Energy: found {len(oe_sensors)} entities")
+    replacements: dict[str, str] = {}
+
+    for placeholder, pattern in OCTOPUS_MAP.items():
+        placeholder_full = f"{OCTOPUS_PREFIX}{placeholder}"
+        for eid in oe_sensors:
+            bare = eid[len(OCTOPUS_PREFIX):]
+            if re.match(pattern, bare):
+                replacements[placeholder_full] = eid
+                print(f"  {placeholder} -> {eid}")
+                break
+        else:
+            print(f"  {placeholder} -> NOT FOUND")
+
+    return replacements
+
+
+def discover_solax_entities(entities: list[dict]) -> dict[str, str]:
+    """Discover SolaX entities by finding the inverter serial prefix."""
+    # Find entities from solax_local platform (excludes old Modbus entities)
+    solax_sensors = sorted(
+        e["entity_id"]
+        for e in entities
+        if e.get("platform") == "solax_local"
+        and e["entity_id"].startswith("sensor.")
+    )
+
+    # Fallback: match by known sensor pattern
+    if not solax_sensors:
+        solax_sensors = sorted(
+            e["entity_id"]
+            for e in entities
+            if re.match(
+                r"sensor\.solax_inverter_[a-z0-9]+_battery_state_of_charge$",
+                e["entity_id"],
+            )
+        )
+
+    if not solax_sensors:
+        print("\nWARNING: No SolaX custom integration entities found")
+        return {}
+
+    # Extract prefix from a known sensor
+    for eid in solax_sensors:
+        match = re.match(
+            r"(sensor\.solax_inverter_[a-z0-9]+_)battery_state_of_charge$", eid
+        )
+        if match:
+            prefix = match.group(1)
+            break
+    else:
+        # Derive prefix from first entity by removing the last segment
+        first = solax_sensors[0]
+        prefix = first.rsplit("_", 1)[0] + "_"
+    print(f"\nSolaX: found {len(solax_sensors)} entities (prefix: {prefix})")
+
+    all_entity_ids = {e["entity_id"] for e in entities}
+    replacements: dict[str, str] = {}
+    for placeholder, suffix in SOLAX_MAP.items():
+        placeholder_full = f"sensor.SOLAX_{placeholder}"
+        real_id = f"{prefix}{suffix}"
+        if real_id in all_entity_ids:
+            replacements[placeholder_full] = real_id
+            print(f"  SOLAX_{placeholder} -> {real_id}")
+        else:
+            print(f"  SOLAX_{placeholder} -> NOT FOUND ({real_id})")
+
+    return replacements
+
+
+def substitute_template(template: str, replacements: dict[str, str]) -> dict:
+    """Replace placeholder entity IDs in the YAML template with real ones."""
+    result = template
+    for placeholder, real_id in replacements.items():
+        result = result.replace(placeholder, real_id)
+
+    # Warn about remaining placeholders
+    remaining = re.findall(
+        r"sensor\.(?:octopus_energy_OCTOPUS_\w+|SOLAX_\w+)",
+        result,
+    )
+    if remaining:
+        unique = sorted(set(remaining))
+        print(f"\nWARNING: {len(unique)} unresolved placeholder(s):")
+        for p in unique:
+            print(f"  {p}")
+
+    return yaml.safe_load(result)
+
+
+async def deploy(token: str) -> None:
+    """Connect to HA WebSocket and deploy the dashboard."""
+    msg_id = 1
+
+    async def send(ws, payload: dict) -> dict:
+        nonlocal msg_id
+        payload["id"] = msg_id
+        msg_id += 1
+        await ws.send(json.dumps(payload))
+        while True:
+            resp = json.loads(await ws.recv())
+            if resp.get("id") == payload["id"]:
+                return resp
+
+    async with websockets.connect(HA_URL) as ws:
+        # Auth
+        auth_req = json.loads(await ws.recv())
+        if auth_req.get("type") != "auth_required":
+            print(f"ERROR: Expected auth_required, got {auth_req.get('type')}")
+            sys.exit(1)
+
+        await ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth_resp = json.loads(await ws.recv())
+        if auth_resp.get("type") != "auth_ok":
+            print(f"ERROR: Authentication failed: {auth_resp}")
+            sys.exit(1)
+        print("Authenticated with Home Assistant")
+
+        # Discover entities
+        entity_resp = await send(ws, {"type": "config/entity_registry/list"})
+        if not entity_resp.get("success"):
+            print(f"ERROR: Failed to list entities: {entity_resp}")
+            sys.exit(1)
+
+        all_entities = entity_resp["result"]
+        replacements: dict[str, str] = {}
+        replacements.update(discover_octopus_entities(all_entities))
+        replacements.update(discover_solax_entities(all_entities))
+
+        if not replacements:
+            print("\nERROR: No entities discovered from any integration")
+            sys.exit(1)
+
+        # Generate final config
+        template = load_template()
+        dashboard_config = substitute_template(template, replacements)
+
+        # Check if dashboard already exists
+        resp = await send(ws, {"type": "lovelace/dashboards/list"})
+        if not resp.get("success"):
+            print(f"ERROR: Failed to list dashboards: {resp}")
+            sys.exit(1)
+
+        existing = [
+            d for d in resp["result"] if d.get("url_path") == DASHBOARD_URL_PATH
+        ]
+
+        if existing:
+            print(
+                f"\nDashboard '{DASHBOARD_URL_PATH}' already exists, updating config..."
+            )
+        else:
+            create_resp = await send(
+                ws,
+                {
+                    "type": "lovelace/dashboards/create",
+                    "url_path": DASHBOARD_URL_PATH,
+                    "title": DASHBOARD_TITLE,
+                    "icon": DASHBOARD_ICON,
+                    "require_admin": False,
+                    "show_in_sidebar": True,
+                },
+            )
+            if not create_resp.get("success"):
+                print(f"ERROR: Failed to create dashboard: {create_resp}")
+                sys.exit(1)
+            print(f"\nCreated dashboard at /{DASHBOARD_URL_PATH}")
+
+        # Save the dashboard config
+        save_resp = await send(
+            ws,
+            {
+                "type": "lovelace/config/save",
+                "url_path": DASHBOARD_URL_PATH,
+                "config": dashboard_config,
+            },
+        )
+        if not save_resp.get("success"):
+            print(f"ERROR: Failed to save dashboard config: {save_resp}")
+            sys.exit(1)
+
+        print("Dashboard config saved successfully!")
+        print(f"View at: http://192.168.1.227:8123/{DASHBOARD_URL_PATH}")
+
+
+def main() -> None:
+    token = load_token()
+    asyncio.run(deploy(token))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 5-section Energy Intelligence dashboard: Right Now, Yesterday's Review, Tomorrow's Outlook, Energy Ratios, Weekly Trends
- Deploy script with multi-integration entity discovery (Octopus Energy regex, SolaX platform+prefix, UK Carbon Intensity fixed names)
- Smart status markdown with context-aware advice (exporting solar / charging battery / expensive period / high carbon / clean grid)

## Test plan
- [x] Deploy script discovers 10/13 Octopus + 10/10 SolaX entities
- [x] Dashboard deploys via WebSocket
- [ ] Verify all 5 sections render after Octopus integration recovers from rate limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)